### PR TITLE
Support for multiple radios toggling the same element id.

### DIFF
--- a/assets/javascript/progressive-reveal.js
+++ b/assets/javascript/progressive-reveal.js
@@ -9,9 +9,16 @@ var helpers = require('./helpers'),
 
 function inputClicked(e, target) {
     target = target || helpers.target(e);
+    var multipleToggle = {};
     _.each(groups[target.name], function (input) {
         var toggle = document.getElementById(input.getAttribute(toggleAttr));
         if (toggle) {
+            if (multipleToggle[toggle.id] === false) {
+                multipleToggle[toggle.id] = true;
+            } else {
+                multipleToggle[toggle.id] = false;
+            }
+
             if (input.checked) {
                 input.setAttribute('aria-expanded', 'true');
                 toggle.setAttribute('aria-hidden', 'false');
@@ -20,6 +27,11 @@ function inputClicked(e, target) {
                 input.setAttribute('aria-expanded', 'false');
                 toggle.setAttribute('aria-hidden', 'true');
                 helpers.addClass(toggle, hiddenClass);
+
+                if (e && target.getAttribute(toggleAttr) === toggle.id && multipleToggle[toggle.id]) {
+                    toggle.setAttribute('aria-hidden', 'false');
+                    helpers.removeClass(toggle, hiddenClass);
+                }
             }
         }
     });

--- a/test/client/spec/spec.progressive-reveal.js
+++ b/test/client/spec/spec.progressive-reveal.js
@@ -49,7 +49,7 @@ describe('Progressive Reveal', function () {
 
         });
 
-        describe('groups', function () {
+        describe('multiple checkbox', function () {
 
             beforeEach(function () {
                 // first checkbox has toggle content
@@ -180,6 +180,41 @@ describe('Progressive Reveal', function () {
                     $('#radio4-toggle').hasClass('js-hidden').should.not.be.ok;
                 });
 
+            });
+
+            describe('multiple radios toggling the same id', function () {
+                beforeEach(function () {
+                    $('form').append('<label for="radio3">');
+                    $('label[for=radio3]').append('<input type="radio" name="group1" id="radio3" data-toggle="radio1-toggle">');
+                    progressiveReveal();
+                });
+
+                it('show content when checked', function () {
+                    $('#radio1').click();
+                    $('#radio1-toggle').hasClass('js-hidden').should.not.be.ok;
+                    $('#radio2-toggle').hasClass('js-hidden').should.be.ok;
+                });
+
+                it('show new content and hide old content if another radio is checked', function () {
+                    $('#radio1').click();
+                    $('#radio2').click();
+                    $('#radio1-toggle').hasClass('js-hidden').should.be.ok;
+                    $('#radio2-toggle').hasClass('js-hidden').should.not.be.ok;
+                });
+
+                it('show content for all radios referencing that id', function () {
+                    $('#radio1').click();
+                    $('#radio1-toggle').hasClass('js-hidden').should.not.be.ok;
+                    $('#radio2-toggle').hasClass('js-hidden').should.be.ok;
+
+                    $('#radio2').click();
+                    $('#radio2-toggle').hasClass('js-hidden').should.not.be.ok;
+                    $('#radio1-toggle').hasClass('js-hidden').should.be.ok;
+
+                    $('#radio3').click();
+                    $('#radio1-toggle').hasClass('js-hidden').should.not.be.ok;
+                    $('#radio2-toggle').hasClass('js-hidden').should.be.ok;
+                });
             });
 
         });


### PR DESCRIPTION
A simple fix to allow the progressive reveal to work on radio buttons that want to toggle the same element.

Added tests to ensure you can see the use case.
